### PR TITLE
add g parameter

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -105,7 +105,7 @@ cldfbench new -h
 
    Again, we can run the command from the command line:
    ```shell script
-   $ cldfbench makecldf theid/cldfbench_theid.py ../glottolog/glottolog
+   $ cldfbench makecldf theid/cldfbench_theid.py --glottolog ../glottolog/glottolog
    INFO    running cmd_makecldf on theid ...
    INFO    ... done theid [0.1 secs]
    ```

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'dev': ['flake8', 'wheel', 'twine'],
         'test': [
             'mock',
-            'pytest>=3.6',
+            'pytest>=5',
             'pytest-mock',
             'pytest-cov',
             'coverage>=4.2',


### PR DESCRIPTION
@xrotwang - working through the tutorial and this command:

`cldfbench makecldf theid/cldfbench_theid.py ../glottolog/glottolog`

fails (for me) if you don't specify the argument paramter:

`cldfbench makecldf theid/cldfbench_theid.py --glottolog ../glottolog/glottolog`