### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'pytest',
         'rfc3986',
         'zenodoclient>=0.3',
+        'tqdm',
     ],
     extras_require={
         'excel': [


### PR DESCRIPTION
The `media` command requires the `tqdm` library, which is not in `install_requires`; a warning is raised with all commands:

```bash
/home/tiago/enki/env/lib/python3.8/site-packages/clldutils/clilib.py:173: UserWarning: No module named 'tqdm' cldfbench.commands.media
  warnings.warn('{0} {1}'.format(e, modname))
```

The import was introduced with commit https://github.com/cldf/cldfbench/commit/6a1da899a18382245fc9a77770b240ba6302766b