### PR TITLE
add more detail to error message

### DIFF
--- a/src/cldfbench/scaffold.py
+++ b/src/cldfbench/scaffold.py
@@ -30,7 +30,9 @@ def iter_scaffolds():
             yield ep.name, ep.load()
         except Exception as e:  # pragma: no cover
             warnings.warn(
-                '{0} loading cldfbench.scaffold {1}'.format(e.__class__.__name__, ep.name))
+                '{0} loading cldfbench.scaffold {1}: {2}'.format(
+                e.__class__.__name__, ep.name, e))
+
 
 
 class Template(object):


### PR DESCRIPTION
I couldn't figure out why the phlorest commands were not getting loaded into the cldfbench scaffold. Turns out I didn't have pyglottolog installed in the venv. This PR makes the error message more explicit by printing the exception