### PR TITLE
Add exe suffix for pip on Windows

### DIFF
--- a/src/cldfbench/util.py
+++ b/src/cldfbench/util.py
@@ -2,6 +2,7 @@ import sys
 import pathlib
 import subprocess
 import importlib.metadata
+import platform
 
 
 def get_entrypoints(group):
@@ -24,8 +25,15 @@ def iter_requirements():
     """
     imported = set(m.split('.')[0].lower() for m in sys.modules.keys())
     pip = pathlib.Path(sys.executable).parent / 'pip'
+
+    if platform.system() == "Windows":
+        pip = pip.with_suffix(".exe")
+
     if not pip.exists():  # pragma: no cover
         pip = pathlib.Path(sys.executable).parent / 'pip3'
+
+        if platform.system() == "Windows":
+            pip = pip.with_suffix(".exe")
     if not pip.exists():  # pragma: no cover
         return
 


### PR DESCRIPTION
`requirements.txt` was empty on Windows platform due to the fact that `pip` could not be found. On Windows, the 'script' is not `pip` but rather `pip.exe`. See also https://github.com/lexibank/pylexibank/issues/272#issuecomment-1803902903.