### PR TITLE
pyproject.toml for new cldfbenches

### DIFF
--- a/src/cldfbench/dataset_template/.github/workflows/cldf-validation.yml
+++ b/src/cldfbench/dataset_template/.github/workflows/cldf-validation.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: [3.12]
 
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -26,4 +26,4 @@ jobs:
         pip install pytest-cldf
     - name: Test with pytest
       run: |
-        pytest --cldf-metadata=cldf/cldf-metadata.json test.py 
+        pytest --cldf-metadata=cldf/cldf-metadata.json test.py

--- a/src/cldfbench/dataset_template/pyproject.toml
+++ b/src/cldfbench/dataset_template/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
If I understood their warning correctly, *pip* is gonna enforce that every project needs to have a `pyproject.toml` (including dev environments).

I added one to the cldfbench template, so that new CLDF projects are good to go from the start.

(I also bumped some of the version info in the template's CI config)